### PR TITLE
refactor

### DIFF
--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -8,7 +8,6 @@ import feedparser
 import urllib.parse as urlparse
 from datetime import datetime, timedelta
 from openai import AzureOpenAI
-from time import mktime
 
 # ログレベルの設定
 logging.basicConfig(level=logging.CRITICAL)
@@ -60,14 +59,14 @@ def get_rss_feed_entries():
 # entries から published が指定された日数以内のエントリーの URL をリスト化
 def get_update_urls(days):
     entries = get_rss_feed_entries()
-    start_date = datetime.now() - timedelta(days=days)  # 取得開始日
+    start_date = datetime.now().astimezone() - timedelta(days=days)  # 取得開始日
     urls = []
     for entry in entries:
-        published = entry.published_parsed
-        if published is None:
+        # 'Thu, 23 Jan 2025 21:30:21 Z' を datetime に変換
+        published_at = datetime.strptime(entry.published, '%a, %d %b %Y %H:%M:%S %z').astimezone()
+        if published_at is None:
             continue
-        rss_published_datetime = datetime.fromtimestamp(mktime(published))
-        if (rss_published_datetime > start_date):
+        if (published_at > start_date):
             urls.append(entry.link)
     return urls
 

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -23,6 +23,10 @@ systemprompt = ("渡されたデータに含まれている Azure のアップ�
                 "リンク用のURLやマークダウンは含まず、プレーンテキストで出力してください。")
 
 
+# 日付フォーマット 'Thu, 23 Jan 2025 21:30:21 Z' は RSS フィードの published で使用
+DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %z'
+
+
 # 環境変数のチェック
 def environment_check():
     if (os.getenv("API_KEY") == "" or os.getenv("API_KEY") is None or
@@ -62,8 +66,8 @@ def get_update_urls(days):
     start_date = datetime.now().astimezone() - timedelta(days=days)  # 取得開始日
     urls = []
     for entry in entries:
-        # 'Thu, 23 Jan 2025 21:30:21 Z' を datetime に変換
-        published_at = datetime.strptime(entry.published, '%a, %d %b %Y %H:%M:%S %z').astimezone()
+        # DATE_FORMAT から datetime に変換
+        published_at = datetime.strptime(entry.published, DATE_FORMAT).astimezone()
         if published_at is None:
             continue
         if (published_at > start_date):

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, MagicMock
 import azureupdatehelper
 import os
 from datetime import datetime
-import time
 
 
 class TestEnvironmentCheck(unittest.TestCase):
@@ -50,11 +49,12 @@ class TestGetUpdateUrls(unittest.TestCase):
 
         mock_entry = MagicMock()
         mock_entry.published = 'Sat, 2 Nov 2024 21:45:07 Z'
-        mock_entry.published_parsed = time.struct_time((2024, 11, 2, 21, 45, 7, 5, 307, 0))
         mock_entry.link = 'https://example.com/update1'
         mock_get_rss_feed_entries.return_value = [mock_entry]
 
-        mock_datetime.fromtimestamp.return_value = datetime(2024, 11, 2)
+        mock_datetime.strptime().astimezone.return_value = datetime.strptime(
+            mock_entry.published, '%a, %d %b %Y %H:%M:%S %z'
+        ).astimezone()
 
         urls = azureupdatehelper.get_update_urls(7)
         self.assertEqual(len(urls), 1)
@@ -68,11 +68,12 @@ class TestGetUpdateUrls(unittest.TestCase):
 
         mock_entry = MagicMock()
         mock_entry.published = 'Sat, 2 Nov 2024 21:45:07 Z'
-        mock_entry.published_parsed = time.struct_time((2024, 11, 2, 21, 45, 7, 5, 307, 0))
         mock_entry.link = 'https://example.com/update1'
         mock_get_rss_feed_entries.return_value = [mock_entry]
 
-        mock_datetime.fromtimestamp.return_value = datetime(2024, 11, 2)
+        mock_datetime.strptime().astimezone.return_value = datetime.strptime(
+            mock_entry.published, '%a, %d %b %Y %H:%M:%S %z'
+        ).astimezone()
 
         urls = azureupdatehelper.get_update_urls(1)
         self.assertEqual(len(urls), 0)
@@ -85,11 +86,10 @@ class TestGetUpdateUrls(unittest.TestCase):
 
         mock_entry = MagicMock()
         mock_entry.published = None
-        mock_entry.published_parsed = None
         mock_entry.link = None
         mock_get_rss_feed_entries.return_value = [mock_entry]
 
-        mock_datetime.fromtimestamp.return_value = None
+        mock_datetime.strptime().astimezone.return_value = None
 
         urls = azureupdatehelper.get_update_urls(7)
         self.assertEqual(len(urls), 0)

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -53,7 +53,7 @@ class TestGetUpdateUrls(unittest.TestCase):
         mock_get_rss_feed_entries.return_value = [mock_entry]
 
         mock_datetime.strptime().astimezone.return_value = datetime.strptime(
-            mock_entry.published, '%a, %d %b %Y %H:%M:%S %z'
+            mock_entry.published, azureupdatehelper.DATE_FORMAT
         ).astimezone()
 
         urls = azureupdatehelper.get_update_urls(7)
@@ -72,7 +72,7 @@ class TestGetUpdateUrls(unittest.TestCase):
         mock_get_rss_feed_entries.return_value = [mock_entry]
 
         mock_datetime.strptime().astimezone.return_value = datetime.strptime(
-            mock_entry.published, '%a, %d %b %Y %H:%M:%S %z'
+            mock_entry.published, azureupdatehelper.DATE_FORMAT
         ).astimezone()
 
         urls = azureupdatehelper.get_update_urls(1)


### PR DESCRIPTION
This pull request includes updates to the `azureupdatehelper.py` script and its corresponding tests to improve the handling of RSS feed entry dates and remove unnecessary dependencies.

Improvements to date handling:

* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L63-R69): Changed the `start_date` calculation in `get_update_urls` to use `datetime.now().astimezone()` for timezone awareness and updated the parsing of the `published` date string to use `datetime.strptime(...).astimezone()`.

Codebase simplification:

* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L11): Removed the unused `mktime` import.
* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aL6): Removed the `time` import and updated the test cases to mock `datetime.strptime(...).astimezone()` instead of `time.struct_time` and `datetime.fromtimestamp`. [[1]](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aL6) [[2]](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aL53-R57) [[3]](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aL71-R76) [[4]](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aL88-R92)