### PR TITLE
Add get_a_href_from_html

### DIFF
--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -154,6 +154,11 @@ def remove_html_tags(text):
     return re.sub(r'<[^>]*?>', '', text)
 
 
+# description から a タグの href を取得
+def get_a_href_from_html(html):
+    return re.findall(r'<a href="([^"]*)"', html)
+
+
 # 引数に渡された URL から、Azure Update の記事 ID を取得して Azure Update API に HTTP Get を行い、その記事を要約する
 def read_and_summary(client, url):
     # URL からデータをダウンロード

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -248,5 +248,36 @@ class TestRemoveHtmlTags(unittest.TestCase):
         self.assertEqual(azureupdatehelper.remove_html_tags(text), "")
 
 
+class TestGetAHrefFromHtml(unittest.TestCase):
+    def test_get_a_href_from_html_no_links(self):
+        html_content = "No anchor tags here."
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(links, [], "Expected empty list when no <a> tags present.")
+
+    def test_get_a_href_from_html_single_link(self):
+        html_content = '<p>Click <a href="https://example.com">here</a> to visit.</p>'
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1, "Expected one link in the list.")
+        self.assertEqual(links[0], "https://example.com")
+
+    def test_get_a_href_from_html_multiple_links(self):
+        html_content = '''
+            <div>
+                <a href="https://example.com/page1">Link1</a>
+                <a href="https://example.com/page2">Link2</a>
+                <a href="https://example.com/page3">Link3</a>
+            </div>
+        '''
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 3)
+        self.assertIn("https://example.com/page1", links)
+        self.assertIn("https://example.com/page2", links)
+        self.assertIn("https://example.com/page3", links)
+
+    def test_get_a_href_from_html_empty_string(self):
+        links = azureupdatehelper.get_a_href_from_html("")
+        self.assertEqual(links, [], "Expected empty list for empty HTML string.")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request introduces a new function to extract `href` attributes from `a` tags in HTML content and includes corresponding unit tests to ensure its functionality.

### New Feature Addition:

* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0R157-R161): Added a new function `get_a_href_from_html` to extract `href` attributes from `a` tags in a given HTML string.

### Unit Tests:

* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR251-R281): Added a new test class `TestGetAHrefFromHtml` with multiple test cases to verify the behavior of the `get_a_href_from_html` function, including scenarios with no links, a single link, multiple links, and an empty string.