### PR TITLE
support dobule quote and single quote and no quote in get_a_href_from…

### DIFF
--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -157,7 +157,7 @@ def remove_html_tags(text):
 
 # description から a タグの href を取得
 def get_a_href_from_html(html):
-    return re.findall(r'<a href="([^"]*)"', html)
+    return re.findall(r'<a\s+href\s*=\s*["\']?([^"\'\s>]+)["\']?', html)
 
 
 # 引数に渡された URL から、Azure Update の記事 ID を取得して Azure Update API に HTTP Get を行い、その記事を要約する

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -260,12 +260,24 @@ class TestGetAHrefFromHtml(unittest.TestCase):
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com")
 
+    def test_get_a_href_from_html_single_link_and_single_quote(self):
+        html_content = "<p>Click <a href='https://example.com'>here</a> to visit.</p>"
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1, "Expected one link in the list.")
+        self.assertEqual(links[0], "https://example.com")
+
+    def test_get_a_href_from_html_single_link_and_no_quote(self):
+        html_content = '<p>Click <a href=https://example.com>here</a> to visit.</p>'
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1, "Expected one link in the list.")
+        self.assertEqual(links[0], "https://example.com")
+
     def test_get_a_href_from_html_multiple_links(self):
         html_content = '''
             <div>
                 <a href="https://example.com/page1">Link1</a>
-                <a href="https://example.com/page2">Link2</a>
-                <a href="https://example.com/page3">Link3</a>
+                <a href='https://example.com/page2'>Link2</a>
+                <a href=https://example.com/page3>Link3</a>
             </div>
         '''
         links = azureupdatehelper.get_a_href_from_html(html_content)


### PR DESCRIPTION
This pull request includes updates to the `azureupdatehelper.py` and `test_azureupdatehelper.py` files to enhance the functionality of the `get_a_href_from_html` function and add new test cases for it. The most important changes are as follows:

Improvements to HTML parsing:

* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L160-R160): Modified the `get_a_href_from_html` function to handle various formats of the `href` attribute, including single quotes and no quotes.

Enhancements to test coverage:

* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR263-R280): Added new test cases to verify that the `get_a_href_from_html` function correctly handles `href` attributes with single quotes and no quotes.