### PR TITLE
Display reference links within article summaries

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,12 +101,23 @@ if st.button('PPTX 生成'):
         p.text = result["summary"]
         p.level = 0
 
+        # 参照リンク
         p = body_shape.text_frame.add_paragraph()
+        text = "参照リンク"
+        st.write(text)
+        p.text = text
         p.level = 1
-        r = p.add_run()
-        r.text = result["url"]
-        hlink = r.hyperlink
-        hlink.address = result["url"]
+
+        # 記事内のリンク
+        links = result["referenceLink"].split(",")
+        for link in links:
+            link = link.strip()
+            st.write(link)
+            p = body_shape.text_frame.add_paragraph()
+            p.level = 2
+            r = p.add_run()
+            r.text = link
+            r.hyperlink.address = link
 
         # 公開日の時刻データに標準準拠しないタイムゾーン情報が入っているので、それを削除してから利用。
         p = body_shape.text_frame.add_paragraph()
@@ -114,8 +125,21 @@ if st.button('PPTX 生成'):
         pubDate = result["publishedDate"][:idx]
 
         logging.info(result["publishedDate"])
-        p.text = "公開日: " + datetime.strptime(pubDate, '%Y-%m-%dT%H:%M:%S').strftime('%Y年%m月%d日')
+        text = "公開日: " + datetime.strptime(pubDate, '%Y-%m-%dT%H:%M:%S').strftime('%Y年%m月%d日')
+        st.write(text)
+        p.text = text
+        p.level = 1
+
+        # 記事リンク
+        p = body_shape.text_frame.add_paragraph()
         p.level = 2
+        r = p.add_run()
+        r.text = result["url"]
+        st.write(url)
+        hlink = r.hyperlink
+        hlink.address = result["url"]
+
+
         print("\n")
 
     # PPTX を保存

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -185,7 +185,7 @@ class TestSummarizeArticle(unittest.TestCase):
             "description": "<p>Some description with <a href='https://example.com'>link</a></p>"
         }
         summary = azureupdatehelper.summarize_article(mock_client, mock_deployment_name, article)
-        self.assertEqual(summary, "Fake Summary")
+        self.assertEqual(summary, ('Fake Summary', 'https://example.com'))
 
         content = 'タイトル: Dummy article content\n製品: Azure\n説明: Some description with link\n説明内のリンク: https://example.com'
         mock_chat_completions.create.assert_called_once_with(


### PR DESCRIPTION
This pull request includes several changes to the `azureupdatehelper.py`, `main.py`, and `test_azureupdatehelper.py` files to enhance the handling and presentation of reference links within article summaries. The most important changes include adding the reference links to the summary output, updating the main script to display these links, and adjusting the corresponding tests.

Enhancements to article summary handling:

* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0R118-R123): Modified the `summarize_article` function to extract and return reference links along with the summary. [[1]](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0R118-R123) [[2]](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L132-R133)
* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L178-R179): Updated the `read_and_summary` function to include reference links in the returned data structure. [[1]](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L178-R179) [[2]](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L204-R206)

Updates to main script:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R104-R142): Added code to display reference links in the PowerPoint presentation generated by the script.

Adjustments to tests:

* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aL188-R188): Modified the test for `summarize_article` to check for the inclusion of reference links in the returned tuple.