### PR TITLE
Display published_at and to old_at

### DIFF
--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -257,11 +257,9 @@ def main():
     print("Environment variables OK.")
     client, deployment_name = azure_openai_client(os.getenv("API_KEY"), os.getenv("API_ENDPOINT"))
     print("Client: ", client)
-
     entries = get_rss_feed_entries()
     print(f"RSS フィードのエントリーは {len(entries)} 件です。")
-
-    urls = get_update_urls(DAYS)
+    urls = target_update_urls(entries, DAYS)
     print(f"Azureアップデートは {len(urls)} 件です。")
     print('含まれる Azure Update の URL は以下の通りです。')
     print(urls)

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -67,14 +67,16 @@ def azure_openai_client(key, endpoint):
 def latest_article_date(entries):
     if len(entries) == 0:
         return None
-    return entries[0].published
+    # 日付 yyyy-mm-dd に変換
+    return datetime.strptime(entries[0].published, DATE_FORMAT).astimezone().strftime('%Y-%m-%d')
 
 
 # entries から published が指定された日数以内のエントリーの URL をリスト化
 def oldest_article_date(entries):
     if len(entries) == 0:
         return None
-    return entries[-1].published
+    # 日付 yyyy-mm-dd に変換
+    return datetime.strptime(entries[-1].published, DATE_FORMAT).astimezone().strftime('%Y-%m-%d')
 
 
 # Azure Update の RSS フィードを読み込んでエントリーを取得

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -63,6 +63,20 @@ def azure_openai_client(key, endpoint):
     return AzureOpenAI(api_key=key, api_version=api_version, azure_endpoint=endpoint), deployment_name
 
 
+# entries から published が指定された日数以内のエントリーの URL をリスト化
+def latest_article_date(entries):
+    if len(entries) == 0:
+        return None
+    return entries[0].published
+
+
+# entries から published が指定された日数以内のエントリーの URL をリスト化
+def oldest_article_date(entries):
+    if len(entries) == 0:
+        return None
+    return entries[-1].published
+
+
 # Azure Update の RSS フィードを読み込んでエントリーを取得
 def get_rss_feed_entries():
     feed = feedparser.parse(RSS_URL)

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -98,6 +98,20 @@ def get_update_urls(days):
     return urls
 
 
+# entries から published が指定された日数以内のエントリーの URL をリスト化
+def target_update_urls(entries, days):
+    start_date = datetime.now().astimezone() - timedelta(days=days)  # 取得開始日
+    urls = []
+    for entry in entries:
+        # DATE_FORMAT から datetime に変換
+        published_at = datetime.strptime(entry.published, DATE_FORMAT).astimezone()
+        if published_at is None:
+            continue
+        if (published_at > start_date):
+            urls.append(entry.link)
+    return urls
+
+
 # URL から記事を順番に取得する
 def get_article(url):
     # 記事用の url 生成

--- a/main.py
+++ b/main.py
@@ -19,6 +19,11 @@ name_prefix = st.text_input('スライドのファイル名を拡張子なしで
 # ファイル名が重複しないように今日の日付(YYYYMMDDHHMMSS)
 save_name = name_prefix + datetime.now().strftime('%Y%m%d%H%M%S') + '.pptx'
 
+# Azure Update API からデータを取得
+st.write('データ取得中...')
+entries = azup.get_rss_feed_entries()
+st.write(f"取得した Azure Update のエントリーは {azup.oldest_article_date(entries)} から {azup.latest_article_date(entries)} の {len(entries)} 件です。")
+
 # ボタンを押すと Azure Update API からデータを取得して PPTX を生成
 if st.button('PPTX 生成'):
     # 環境変数が不足している場合はエラーを表示して終了
@@ -26,9 +31,6 @@ if st.button('PPTX 生成'):
         st.error('環境変数が不足しています。.env ファイルを確認してください。')
         st.stop()
 
-    # Azure Update API からデータを取得
-    st.write('データ取得中...')
-    entries = azup.get_rss_feed_entries
     urls = azup.target_update_urls(entries, days)
     st.write(f"Azureアップデートは {len(urls)} 件です。")
     st.write('含まれる Azure Update の URL は以下の通りです。')

--- a/main.py
+++ b/main.py
@@ -22,7 +22,10 @@ save_name = name_prefix + datetime.now().strftime('%Y%m%d%H%M%S') + '.pptx'
 # Azure Update API からデータを取得
 st.write('データ取得中...')
 entries = azup.get_rss_feed_entries()
-st.write(f"取得した Azure Update のエントリーは {azup.oldest_article_date(entries)} から {azup.latest_article_date(entries)} の {len(entries)} 件です。")
+st.write(
+    f"取得した Azure Update のエントリーは {azup.oldest_article_date(entries)} から "
+    f"{azup.latest_article_date(entries)} の {len(entries)} 件です。"
+)
 
 # ボタンを押すと Azure Update API からデータを取得して PPTX を生成
 if st.button('PPTX 生成'):

--- a/main.py
+++ b/main.py
@@ -28,8 +28,8 @@ if st.button('PPTX 生成'):
 
     # Azure Update API からデータを取得
     st.write('データ取得中...')
-    urls = azup.get_update_urls(days)
-
+    entries = azup.get_rss_feed_entries
+    urls = azup.target_update_urls(entries, days)
     st.write(f"Azureアップデートは {len(urls)} 件です。")
     st.write('含まれる Azure Update の URL は以下の通りです。')
     st.write(urls)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ load_dotenv()
 st.title('Azure Update PPTX Generator')
 
 # 何日前までのアップデートを取得するか streamlit で指定
-days = st.slider('何日前までのアップデートを取得しますか？', 1, 30, 7)
+days = st.slider('何日前までのアップデートを取得しますか？', 1, 90, 7)
 
 # スライドのファイル名の拡張子なしの文字列を入力
 name_prefix = st.text_input('スライドのファイル名を拡張子なしで入力してください。', 'AzureUpdates')

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -296,5 +296,46 @@ class TestGetAHrefFromHtml(unittest.TestCase):
         self.assertEqual(links, [], "Expected empty list for empty HTML string.")
 
 
+class TestLatestArticleDate(unittest.TestCase):
+    def test_latest_article_date_no_entries(self):
+        entries = []
+        result = azureupdatehelper.latest_article_date(entries)
+        self.assertIsNone(result)
+
+    def test_latest_article_date_single_entry(self):
+        mock_entry = MagicMock()
+        mock_entry.published = "Thu, 31 Oct 2024 21:45:07 Z"
+        entries = [mock_entry]
+        result = azureupdatehelper.latest_article_date(entries)
+        self.assertEqual(result, mock_entry.published)
+
+    def test_latest_article_date_multiple_entries(self):
+        mock_entry1 = MagicMock()
+        mock_entry1.published = "Thu, 31 Oct 2024 21:45:07 Z"
+        mock_entry2 = MagicMock()
+        mock_entry2.published = "Fri, 1 Nov 2024 09:30:07 Z"
+        entries = [mock_entry1, mock_entry2]
+        result = azureupdatehelper.latest_article_date(entries)
+        self.assertEqual(result, mock_entry1.published)
+
+
+class TestOldestArticleDate(unittest.TestCase):
+    def test_oldest_article_date_empty_entries(self):
+        entries = []
+        self.assertIsNone(azureupdatehelper.oldest_article_date(entries))
+
+    def test_oldest_article_date_single_entry(self):
+        entries = [MagicMock(published='Thu, 31 Oct 2024 21:45:07 Z')]
+        self.assertEqual(azureupdatehelper.oldest_article_date(entries), 'Thu, 31 Oct 2024 21:45:07 Z')
+
+    def test_oldest_article_date_multiple_entries(self):
+        entries = [
+            MagicMock(published='Thu, 31 Oct 2024 21:45:07 Z'),
+            MagicMock(published='Fri, 01 Nov 2024 10:30:00 Z'),
+            MagicMock(published='Sat, 02 Nov 2024 05:15:20 Z')
+        ]
+        self.assertEqual(azureupdatehelper.oldest_article_date(entries), 'Sat, 02 Nov 2024 05:15:20 Z')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -307,7 +307,7 @@ class TestLatestArticleDate(unittest.TestCase):
         mock_entry.published = "Thu, 31 Oct 2024 21:45:07 Z"
         entries = [mock_entry]
         result = azureupdatehelper.latest_article_date(entries)
-        self.assertEqual(result, mock_entry.published)
+        self.assertEqual(result, '2024-11-01')
 
     def test_latest_article_date_multiple_entries(self):
         mock_entry1 = MagicMock()
@@ -316,7 +316,7 @@ class TestLatestArticleDate(unittest.TestCase):
         mock_entry2.published = "Fri, 1 Nov 2024 09:30:07 Z"
         entries = [mock_entry1, mock_entry2]
         result = azureupdatehelper.latest_article_date(entries)
-        self.assertEqual(result, mock_entry1.published)
+        self.assertEqual(result, '2024-11-01')
 
 
 class TestOldestArticleDate(unittest.TestCase):
@@ -326,7 +326,7 @@ class TestOldestArticleDate(unittest.TestCase):
 
     def test_oldest_article_date_single_entry(self):
         entries = [MagicMock(published='Thu, 31 Oct 2024 21:45:07 Z')]
-        self.assertEqual(azureupdatehelper.oldest_article_date(entries), 'Thu, 31 Oct 2024 21:45:07 Z')
+        self.assertEqual(azureupdatehelper.oldest_article_date(entries), '2024-11-01')
 
     def test_oldest_article_date_multiple_entries(self):
         entries = [
@@ -334,7 +334,7 @@ class TestOldestArticleDate(unittest.TestCase):
             MagicMock(published='Fri, 01 Nov 2024 10:30:00 Z'),
             MagicMock(published='Sat, 02 Nov 2024 05:15:20 Z')
         ]
-        self.assertEqual(azureupdatehelper.oldest_article_date(entries), 'Sat, 02 Nov 2024 05:15:20 Z')
+        self.assertEqual(azureupdatehelper.oldest_article_date(entries), '2024-11-02')
 
 
 if __name__ == '__main__':

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -307,7 +307,7 @@ class TestLatestArticleDate(unittest.TestCase):
         mock_entry.published = "Thu, 31 Oct 2024 21:45:07 Z"
         entries = [mock_entry]
         result = azureupdatehelper.latest_article_date(entries)
-        self.assertEqual(result, '2024-11-01')
+        self.assertEqual(result, '2024-10-31')
 
     def test_latest_article_date_multiple_entries(self):
         mock_entry1 = MagicMock()
@@ -316,7 +316,7 @@ class TestLatestArticleDate(unittest.TestCase):
         mock_entry2.published = "Fri, 1 Nov 2024 09:30:07 Z"
         entries = [mock_entry1, mock_entry2]
         result = azureupdatehelper.latest_article_date(entries)
-        self.assertEqual(result, '2024-11-01')
+        self.assertEqual(result, '2024-10-31')
 
 
 class TestOldestArticleDate(unittest.TestCase):
@@ -326,7 +326,7 @@ class TestOldestArticleDate(unittest.TestCase):
 
     def test_oldest_article_date_single_entry(self):
         entries = [MagicMock(published='Thu, 31 Oct 2024 21:45:07 Z')]
-        self.assertEqual(azureupdatehelper.oldest_article_date(entries), '2024-11-01')
+        self.assertEqual(azureupdatehelper.oldest_article_date(entries), '2024-10-31')
 
     def test_oldest_article_date_multiple_entries(self):
         entries = [


### PR DESCRIPTION
This pull request includes several changes to the `azureupdatehelper.py` and `main.py` files, as well as updates to the test suite. The main focus of these changes is to enhance the functionality of the Azure Update helper by adding new methods to filter and retrieve update entries based on their publication dates, and to increase the flexibility of the date range for updates in the user interface.

Enhancements to Azure Update helper functionality:

* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0R66-R81): Added `latest_article_date` and `oldest_article_date` methods to extract the latest and oldest publication dates from a list of entries. These methods convert the dates to the `yyyy-mm-dd` format.
* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0R103-R116): Introduced the `target_update_urls` method to filter entries and retrieve URLs of updates published within a specified number of days.
* [`azureupdatehelper.py`](diffhunk://#diff-83c344d783e417700aa93c9e8c5111ad305683ed48e8c742a85a0b1fe82067d0L232-R264): Updated the `main` function to use the new `target_update_urls` method instead of `get_update_urls`, improving the filtering of update entries.

User interface improvements:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L15-R37): Extended the date range for the update slider from a maximum of 30 days to 90 days, allowing users to retrieve updates from a longer period.
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L15-R37): Modified the data retrieval process to display the range of dates for the retrieved Azure Update entries, using the new `latest_article_date` and `oldest_article_date` methods.

Test suite updates:

* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR299-R339): Added new test cases for the `latest_article_date` and `oldest_article_date` methods to ensure they handle various scenarios, such as no entries, single entry, and multiple entries.