### PR TITLE
do not set expires option

### DIFF
--- a/add_meta_tags.py
+++ b/add_meta_tags.py
@@ -27,12 +27,12 @@ meta_tags = [
     {'property': 'og:url', 'content': 'https://azure.koudaiii.com'},
     {'property': 'og:title', 'content': 'Azure Updates Summary'},
     {'property': 'og:description', 'content': 'Azure Updates を要約して PPTX にまとめます。'},
-    {'property': 'og:image', 'content': 'https://opengraph.b-cdn.net/production/images/189613b4-180c-4fec-8715-908d5f86146b.png?token=5O8n6YskRFyXUC_Gi1qNqF3ocTOGCVxcLXzU4WcGbKg&height=630&width=1200&expires=33276555879'},
+    {'property': 'og:image', 'content': 'https://koudaiii.com/azure_update_summary.png'},
 
     # X
     {'property': 'twitter:domain', 'content': 'azure.koudaiii.com'},
     {'property': 'twitter:url', 'content': 'https://azure.koudaiii.com'},
-    {'name': 'twitter:image', 'content': 'https://opengraph.b-cdn.net/production/images/189613b4-180c-4fec-8715-908d5f86146b.png?token=5O8n6YskRFyXUC_Gi1qNqF3ocTOGCVxcLXzU4WcGbKg&height=630&width=1200&expires=33276555879'},
+    {'name': 'twitter:image', 'content': 'https://koudaiii.com/azure_update_summary.png'},
     {'name': 'twitter:title', 'content': 'Azure Updates Summary'},
     {'name': 'twitter:description', 'content': 'Azure Updates を要約して PPTX にまとめます。'},
     {'name': 'twitter:card', 'content': 'summary_large_image'},


### PR DESCRIPTION
This pull request includes updates to the Open Graph and Twitter meta tags in the `add_meta_tags.py` file. The changes modify the URLs for the `og:image` and `twitter:image` properties to point to a new image location.

Updates to meta tags:

* [`add_meta_tags.py`](diffhunk://#diff-9977161537dd7d1b50f84a13852b159af82ebe1b041dbd1b7cfb83e9288fa4e7L30-R35): Updated the `og:image` and `twitter:image` properties to use a new image URL (`https://koudaiii.com/azure_update_summary.png`).