### PR TITLE
Add public preview banner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 *
 !azureupdatehelper.py
-!add_meta_tags.py
+!add_meta_tags_and_header-banner.py
 !main.py
 !requirements.txt
 !script/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-# Copy the add_meta_tags.py script
-COPY add_meta_tags.py .
+# Copy the add_meta_tags_and_header-banner.py script
+COPY add_meta_tags_and_header-banner.py .
 
-# Run the script to add meta tags
-RUN python add_meta_tags.py
+# Run the script to add meta tags and header banner
+RUN python add_meta_tags_and_header-banner.py
 
 COPY . .
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Takashi Okawa
+Copyright (c) 2024 Takashi Okawa and Kodai Sakabe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/add_meta_tags_and_header-banner.py
+++ b/add_meta_tags_and_header-banner.py
@@ -34,7 +34,7 @@ meta_tags = [
     {'property': 'og:description', 'content': 'Azure Updates を要約して PPTX にまとめます。'},
     {'property': 'og:image', 'content': 'https://koudaiii.com/azure_update_summary.png'},
 
-    # X
+    # Twitter
     {'property': 'twitter:domain', 'content': 'azure.koudaiii.com'},
     {'property': 'twitter:url', 'content': 'https://azure.koudaiii.com'},
     {'name': 'twitter:image', 'content': 'https://koudaiii.com/azure_update_summary.png'},
@@ -52,8 +52,27 @@ for tag in meta_tags:
         new_tag[key] = value
     soup.head.append(new_tag)
 
+# Add custom CSS and HTML for the header banner
+style_tag = soup.new_tag('style')
+style_tag.string = """
+.header-banner {
+    color: black;
+    text-align: center;
+    font-size: 14px;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 999991;
+}
+"""
+soup.head.append(style_tag)
+
+banner_div = soup.new_tag('div', **{'class': 'header-banner'})
+banner_div.string = "Public Preview"
+soup.body.insert(0, banner_div)
+
 # Save the modified HTML
 with open(streamlit_path, 'w') as file:
     file.write(str(soup))
 
-print("Meta tags have been added to the Streamlit index.html file.")
+print("Meta tags and header banner have been added to the Streamlit index.html file.")

--- a/main.py
+++ b/main.py
@@ -16,13 +16,28 @@ st.set_page_config(page_title="Azure Updates Summary",
                    layout="centered",
                    menu_items={
                        "Report a bug": "https://github.com/koudaiii/AzureUpdatePPTX/issues",
-                       "About": "https://koudaiii.com"
+                       "About": """
+                                ### Azure Updates Summary
+                                本サイトの使用においては、次の制限、制約をご理解の上、活用ください。
+                                ### 目的外利用の禁止
+                                本サイトは Azure Updates において、円滑に情報を受け取ることを目的に作成されています。また、非公式の有志によって運営されています。この目的に反する利用はお断りいたします。
+                                ### 公式情報の確認
+                                本サイトの記載内容について一切の責任を負いません。公式情報については、 Azure Updates をご確認ください。
+                                ### Disclaimer
+                                本サイトの記載内容によって発生したいかなる損害について、一切の責任を負いません。本サイトの記載内容は、予告なく変更されることがあります。現在パブリックプレビュー中のため、予告なくサービスが終了する可能性があります。
+                                ### Author
+                                Kodai Sakabe @koudaiii https://koudaiii.com
+                                """,
                    })
 
 # Set the browser tab title
-st.title('Azure Updates')
+st.title('Azure Updates Summary')
 # description
-st.markdown('<a href="https://azure.microsoft.com/updates" target="_blank">Azure Updates</a> から要約します。', unsafe_allow_html=True)
+st.markdown("""
+            <a href="https://azure.microsoft.com/updates" target="_blank">Azure Updates</a> から要約します。
+            公式情報についてはリンク先よりご確認ください。<br>
+            本サイトの利用に際しては、Aboutページの記載内容に同意したものとみなします。
+            """, unsafe_allow_html=True)
 
 # ファイル名が重複しないように今日の日付(YYYYMMDDHHMMSS)
 save_name = 'AzureUpdates' + datetime.now().strftime('%Y%m%d%H%M%S') + '.pptx'


### PR DESCRIPTION
This pull request includes several changes to update the `add_meta_tags.py` script, add a header banner, and update the `About` section in the `main.py` file. The most important changes include renaming the script file, adding new functionality to the script, and updating the `About` section with detailed information.

Changes to script and header banner:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5L3-R3): Renamed `add_meta_tags.py` to `add_meta_tags_and_header-banner.py`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L9-R13): Updated to copy and run the renamed script `add_meta_tags_and_header-banner.py`.
* [`add_meta_tags_and_header-banner.py`](diffhunk://#diff-f17f84b1213e5fce29f7e88fd0d53536f8c609da4b85776d852ac0684ca22505L37-R37): Added custom CSS and HTML for a header banner and updated meta tags. [[1]](diffhunk://#diff-f17f84b1213e5fce29f7e88fd0d53536f8c609da4b85776d852ac0684ca22505L37-R37) [[2]](diffhunk://#diff-f17f84b1213e5fce29f7e88fd0d53536f8c609da4b85776d852ac0684ca22505R55-R78)

Updates to `main.py`:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L19-R40): Updated the `About` section with detailed usage restrictions, disclaimer, and author information.

Other updates:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated to include Kodai Sakabe as a copyright holder.