### PR TITLE
add test about html tag

### DIFF
--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -204,7 +204,8 @@ def remove_html_tags(text):
 
 # description から a タグの href を取得
 def get_a_href_from_html(html):
-    return re.findall(r'<a\s+href\s*=\s*["\']?([^"\'\s>]+)["\']?', html)
+    soup = BeautifulSoup(html, 'html.parser')
+    return [a['href'] for a in soup.find_all('a', href=True)]
 
 
 # 引数に渡された URL から、Azure Updates の記事 ID を取得して Azure Updates API に HTTP Get を行い、その記事を要約する

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -7,6 +7,7 @@ import feedparser
 import urllib.parse as urlparse
 from datetime import datetime, timedelta
 from openai import AzureOpenAI
+from bs4 import BeautifulSoup
 
 # ログレベルの設定
 logging.basicConfig(level=logging.CRITICAL)
@@ -197,7 +198,8 @@ def docid_from_url(url):
 
 # description から HTML タグを削除
 def remove_html_tags(text):
-    return re.sub(r'<[^>]*?>', '', text)
+    soup = BeautifulSoup(text, 'html.parser')
+    return soup.get_text()
 
 
 # description から a タグの href を取得

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -248,6 +248,11 @@ class TestRemoveHtmlTags(unittest.TestCase):
         expected = "Paragraph with nested tag"
         self.assertEqual(azureupdatehelper.remove_html_tags(text), expected)
 
+    def test_remove_html_tags_with_special_characters(self):
+        html_content = '<p>Special characters: &amp; &lt; &gt;</p>'
+        expected_text = 'Special characters: & < >'
+        self.assertEqual(azureupdatehelper.remove_html_tags(html_content), expected_text)
+
     def test_remove_html_tags_empty_string(self):
         text = ""
         self.assertEqual(azureupdatehelper.remove_html_tags(text), "")

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -296,6 +296,24 @@ class TestGetAHrefFromHtml(unittest.TestCase):
         self.assertIn("https://example.com/page2", links)
         self.assertIn("https://example.com/page3", links)
 
+    def test_get_a_href_from_html_with_rel_attributes(self):
+        html_content = '<a rel="noreferrer noopener" href="https://example.com/page1">Learn more</a>'
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1, "Expected one link in the list.")
+        self.assertEqual(links[0], "https://example.com/page1")
+
+    def test_get_a_href_from_html_with_another_rel_attributes(self):
+        html_content = '<a href="https://example.com/page1" rel="noreferrer noopener">Learn more</a>'
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1, "Expected one link in the list.")
+        self.assertEqual(links[0], "https://example.com/page1")
+
+    def test_get_a_href_from_html_with_another_attributes(self):
+        html_content = '<a foo="bar" href="https://example.com/page1">Learn more</a>'
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1, "Expected one link in the list.")
+        self.assertEqual(links[0], "https://example.com/page1")
+
     def test_get_a_href_from_html_empty_string(self):
         links = azureupdatehelper.get_a_href_from_html("")
         self.assertEqual(links, [], "Expected empty list for empty HTML string.")


### PR DESCRIPTION
## Why

I found probrem.  AzureUpdatePPTX unable get url of 'Learn more' in https://azure.microsoft.com/en-us/updates?id=479209 

```html
<a rel="noreferrer noopener" href="https://aka.ms/hs-conversion-v2-preview">Learn more</a>
```

## What

This pull request adds new test cases to the `test_azureupdatehelper.py` file to enhance the coverage of HTML parsing functions. The most important changes include adding tests for handling special characters in HTML content and various attributes within `<a>` tags.

New test cases for HTML parsing functions:

* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR251-R255): Added `test_remove_html_tags_with_special_characters` to ensure special characters are correctly parsed and converted.
* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR299-R316): Added `test_get_a_href_from_html_with_rel_attributes` to verify links with `rel` attributes are correctly extracted.
* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR299-R316): Added `test_get_a_href_from_html_with_another_rel_attributes` to check links with `rel` attributes in different order are correctly handled.
* [`test_azureupdatehelper.py`](diffhunk://#diff-102364ecf84c06f587fd7b1f84dcce5cc2bf3587128fde3b0b1815ec1a976e3aR299-R316): Added `test_get_a_href_from_html_with_another_attributes` to confirm links with additional attributes are correctly parsed.