### PR TITLE
cosmetic

### DIFF
--- a/main.py
+++ b/main.py
@@ -158,7 +158,7 @@ def display_update_info(title, url, published_date, summary, ref_label, ref_link
     st.markdown(f"<small>{ref_label}</small>", unsafe_allow_html=True)
     for link in ref_links:
         st.markdown(
-            f"<p style='line-height:80%; margin-bottom:10px; padding:0;'>"
+            f"<p style='line-height:130%; margin-bottom:10px; padding:0;'>"
             f"<a href='{link}' target='_blank'>{link}</a></p>",
             unsafe_allow_html=True
         )


### PR DESCRIPTION
This pull request includes a small change to the `display_update_info` function in the `main.py` file. The change modifies the line height of the reference links to improve readability.

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L161-R161): Updated the `line-height` style for reference links from `80%` to `130%` in the `display_update_info` function.