### PR TITLE
uniq link

### DIFF
--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -154,7 +154,7 @@ def get_article(url):
 # 記事を要約する
 def summarize_article(client, deployment_name, article):
     try:
-        link = ", ".join(get_a_href_from_html(article['description']))
+        link = ", ".join(get_unique_a_href_from_html(article['description']))
         content = (
             "タイトル: " + article['title'] + "\n"
             + "製品: " + ", ".join(article['products']) + "\n"
@@ -203,7 +203,16 @@ def remove_html_tags(text):
 
 
 # description から a タグの href を取得
-def get_a_href_from_html(html):
+def get_unique_a_href_from_html(html):
+    """
+    Extracts unique href attributes from all <a> tags in the given HTML.
+
+    Args:
+        html (str): A string containing HTML content.
+
+    Returns:
+        list: A list of unique href attribute values from <a> tags.
+    """
     soup = BeautifulSoup(html, 'html.parser')
     return list(dict.fromkeys([a['href'] for a in soup.find_all('a', href=True)]))
 

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -8,6 +8,7 @@ import urllib.parse as urlparse
 from datetime import datetime, timedelta
 from openai import AzureOpenAI
 from bs4 import BeautifulSoup
+from collections import OrderedDict
 
 # ログレベルの設定
 logging.basicConfig(level=logging.CRITICAL)
@@ -205,7 +206,7 @@ def remove_html_tags(text):
 # description から a タグの href を取得
 def get_a_href_from_html(html):
     soup = BeautifulSoup(html, 'html.parser')
-    return list(set([a['href'] for a in soup.find_all('a', href=True)]))
+    return list(OrderedDict.fromkeys([a['href'] for a in soup.find_all('a', href=True)]))
 
 
 # 引数に渡された URL から、Azure Updates の記事 ID を取得して Azure Updates API に HTTP Get を行い、その記事を要約する

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -205,7 +205,7 @@ def remove_html_tags(text):
 # description から a タグの href を取得
 def get_a_href_from_html(html):
     soup = BeautifulSoup(html, 'html.parser')
-    return [a['href'] for a in soup.find_all('a', href=True)]
+    return list(set([a['href'] for a in soup.find_all('a', href=True)]))
 
 
 # 引数に渡された URL から、Azure Updates の記事 ID を取得して Azure Updates API に HTTP Get を行い、その記事を要約する

--- a/azureupdatehelper.py
+++ b/azureupdatehelper.py
@@ -8,7 +8,6 @@ import urllib.parse as urlparse
 from datetime import datetime, timedelta
 from openai import AzureOpenAI
 from bs4 import BeautifulSoup
-from collections import OrderedDict
 
 # ログレベルの設定
 logging.basicConfig(level=logging.CRITICAL)
@@ -206,7 +205,7 @@ def remove_html_tags(text):
 # description から a タグの href を取得
 def get_a_href_from_html(html):
     soup = BeautifulSoup(html, 'html.parser')
-    return list(OrderedDict.fromkeys([a['href'] for a in soup.find_all('a', href=True)]))
+    return list(dict.fromkeys([a['href'] for a in soup.find_all('a', href=True)]))
 
 
 # 引数に渡された URL から、Azure Updates の記事 ID を取得して Azure Updates API に HTTP Get を行い、その記事を要約する

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -259,30 +259,30 @@ class TestRemoveHtmlTags(unittest.TestCase):
 
 
 class TestGetAHrefFromHtml(unittest.TestCase):
-    def test_get_a_href_from_html_no_links(self):
+    def test_get_unique_a_href_from_html_no_links(self):
         html_content = "No anchor tags here."
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(links, [], "Expected empty list when no <a> tags present.")
 
-    def test_get_a_href_from_html_single_link(self):
+    def test_get_unique_a_href_from_html_single_link(self):
         html_content = '<p>Click <a href="https://example.com">here</a> to visit.</p>'
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com")
 
-    def test_get_a_href_from_html_single_link_and_single_quote(self):
+    def test_get_unique_a_href_from_html_single_link_and_single_quote(self):
         html_content = "<p>Click <a href='https://example.com'>here</a> to visit.</p>"
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com")
 
-    def test_get_a_href_from_html_single_link_and_no_quote(self):
+    def test_get_unique_a_href_from_html_single_link_and_no_quote(self):
         html_content = '<p>Click <a href=https://example.com>here</a> to visit.</p>'
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com")
 
-    def test_get_a_href_from_html_multiple_links(self):
+    def test_get_unique_a_href_from_html_multiple_links(self):
         html_content = '''
             <div>
                 <a href="https://example.com/page1">Link1</a>
@@ -290,7 +290,7 @@ class TestGetAHrefFromHtml(unittest.TestCase):
                 <a href=https://example.com/page3>Link3</a>
             </div>
         '''
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 3)
         self.assertIn("https://example.com/page1", links)
         self.assertIn("https://example.com/page2", links)
@@ -304,30 +304,30 @@ class TestGetAHrefFromHtml(unittest.TestCase):
                 <a href=https://example.com/page>Link</a>
             </div>
         '''
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1)
         self.assertIn("https://example.com/page", links)
 
-    def test_get_a_href_from_html_with_rel_attributes(self):
+    def test_get_unique_a_href_from_html_with_rel_attributes(self):
         html_content = '<a rel="noreferrer noopener" href="https://example.com/page1">Learn more</a>'
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com/page1")
 
-    def test_get_a_href_from_html_with_another_rel_attributes(self):
+    def test_get_unique_a_href_from_html_with_another_rel_attributes(self):
         html_content = '<a href="https://example.com/page1" rel="noreferrer noopener">Learn more</a>'
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com/page1")
 
-    def test_get_a_href_from_html_with_another_attributes(self):
+    def test_get_unique_a_href_from_html_with_another_attributes(self):
         html_content = '<a foo="bar" href="https://example.com/page1">Learn more</a>'
-        links = azureupdatehelper.get_a_href_from_html(html_content)
+        links = azureupdatehelper.get_unique_a_href_from_html(html_content)
         self.assertEqual(len(links), 1, "Expected one link in the list.")
         self.assertEqual(links[0], "https://example.com/page1")
 
-    def test_get_a_href_from_html_empty_string(self):
-        links = azureupdatehelper.get_a_href_from_html("")
+    def test_get_unique_a_href_from_html_empty_string(self):
+        links = azureupdatehelper.get_unique_a_href_from_html("")
         self.assertEqual(links, [], "Expected empty list for empty HTML string.")
 
 

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -296,6 +296,18 @@ class TestGetAHrefFromHtml(unittest.TestCase):
         self.assertIn("https://example.com/page2", links)
         self.assertIn("https://example.com/page3", links)
 
+    def test_get_uniq_a_href_from_html_multiple_links(self):
+        html_content = '''
+            <div>
+                <a href="https://example.com/page">Link</a>
+                <a href='https://example.com/page'>Link</a>
+                <a href=https://example.com/page>Link</a>
+            </div>
+        '''
+        links = azureupdatehelper.get_a_href_from_html(html_content)
+        self.assertEqual(len(links), 1)
+        self.assertIn("https://example.com/page", links)
+
     def test_get_a_href_from_html_with_rel_attributes(self):
         html_content = '<a rel="noreferrer noopener" href="https://example.com/page1">Learn more</a>'
         links = azureupdatehelper.get_a_href_from_html(html_content)

--- a/test_azureupdatehelper.py
+++ b/test_azureupdatehelper.py
@@ -296,7 +296,7 @@ class TestGetAHrefFromHtml(unittest.TestCase):
         self.assertIn("https://example.com/page2", links)
         self.assertIn("https://example.com/page3", links)
 
-    def test_get_uniq_a_href_from_html_multiple_links(self):
+    def test_unique_links(self):
         html_content = '''
             <div>
                 <a href="https://example.com/page">Link</a>


### PR DESCRIPTION
## Why


> 「Generally Available: Azure Managed Prometheus Supports Horizontal Pod Autoscaling for Replica Set Pods in AKS」
> [公開日: 2025年03月06日](https://azure.microsoft.com/updates?id=483352)
> Azure Monitor Managed service for Prometheus が、AKS 内の ama-metrics レプリカセットポッドのための Horizontal Pod Autoscaling (HPA) をデフォルトでサポートするようになりました。これにより、Prometheus メトリクスのスクレイピングを行うポッドがメモリ使用率に基づいて自動スケーリングされます。HPA は標準設定で最小 2、最大 12 のレプリカをサポートし、範囲内でカスタマイズが可能です。
> 参照リンク:
> https://aka.ms/prometheus-hpa
> https://aka.ms/prometheus-hpa

I can find same link. this should be uniq link.

## What

fix it.