### PR TITLE
cosmetic

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,8 +256,7 @@ def generate_slide_info(start_date, end_date) -> tuple[str, str]:
 # Azure Updates の URL 一覧を表示
 def display_update_urls(urls):
     update_count = len(urls)
-    st.write(f"Azureアップデートは {update_count} 件です。")
-    st.write("含まれる Azure Updates の URL は以下の通りです。")
+    st.write(f"アップデートは {update_count} 件です。")
     st.write(urls)
 
 


### PR DESCRIPTION
This pull request includes a small change to the `main.py` file. The change modifies the message displayed by the `display_update_urls` function to remove the word "Azure" from the update count message. 

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L259-R259): Updated the message in the `display_update_urls` function to remove the word "Azure" from the update count message.