### PR TITLE
cosmtic

### DIFF
--- a/add_meta_tags_and_header_banner.py
+++ b/add_meta_tags_and_header_banner.py
@@ -3,6 +3,7 @@ import sys
 import shutil
 from bs4 import BeautifulSoup
 import logging
+import textwrap
 
 # ロギング設定
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -75,7 +76,7 @@ def get_meta_tags():
 
 def get_banner_style():
     """ヘッダーバナーのスタイルを返す"""
-    return """
+    return textwrap.dedent("""
     .header-banner {
         color: black;
         text-align: center;
@@ -85,7 +86,7 @@ def get_banner_style():
         width: 100%;
         z-index: 999991;
     }
-    """
+    """)
 
 
 def modify_html(file_path):

--- a/test_add_meta_tags_and_header_banner.py
+++ b/test_add_meta_tags_and_header_banner.py
@@ -51,8 +51,8 @@ class TestAddMetaTagsAndHeaderBanner(unittest.TestCase):
         """find_streamlit_index_path関数のテスト - カスタムパスとデフォルトパスの両方をテスト"""
 
         # カスタムパスのテスト - 存在するパス
-        custom_path = os.path.join(self.test_dir, self.test_html)
-        self.assertEqual(add_meta_tags_and_header_banner.find_streamlit_index_path(custom_path), custom_path)
+        custom_path = self.test_html
+        self.assertEqual(add_meta_tags_and_header_banner.find_streamlit_index_path(custom_path), self.test_html)
 
         # カスタムパスのテスト - 存在しないパス
         custom_path = "/non-existent/path/index.html"


### PR DESCRIPTION
## Ref

fix #45 , #44 

This pull request includes several changes to the `add_meta_tags_and_header_banner.py` and `test_add_meta_tags_and_header_banner.py` files to improve code readability and update test cases. The most important changes include importing the `textwrap` module, using `textwrap.dedent` for multi-line strings, and modifying a test case for better accuracy.

Improvements to code readability:

* [`add_meta_tags_and_header_banner.py`](diffhunk://#diff-f83aaf8be7c93ca9efbf20395d592afd3f699265630271ff43b5fb6a3bc1e7afR6): Imported the `textwrap` module to handle multi-line string dedentation.
* `get_banner_style` function in `add_meta_tags_and_header_banner.py`: Updated to use `textwrap.dedent` for the return value to improve readability and maintain consistent indentation. [[1]](diffhunk://#diff-f83aaf8be7c93ca9efbf20395d592afd3f699265630271ff43b5fb6a3bc1e7afL78-R79) [[2]](diffhunk://#diff-f83aaf8be7c93ca9efbf20395d592afd3f699265630271ff43b5fb6a3bc1e7afL88-R89)

Updates to test cases:

* `test_find_streamlit_index_path` function in `test_add_meta_tags_and_header_banner.py`: Modified the test case to directly use `self.test_html` for both custom path and expected value, ensuring the test checks for the correct path.