### PR TITLE
Fix GitHub Actions permissions to resolve startup failures

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   claude-response:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
## Summary
- Fix missing permissions in GitHub Actions workflows that were causing startup failures
- Add required permissions for Claude Assistant and Docker Image CI workflows

## Changes
- `.github/workflows/claude.yml`: Add contents read, issues write, pull-requests write permissions
- `.github/workflows/docker-image.yml`: Add contents read permission

## Test plan
- [x] Verify GitHub Actions run without permission errors
- [x] Test Claude Assistant workflow triggers properly
- [ ] Test Docker Image CI builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)