### PR TITLE
Display build summary in docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,3 +44,16 @@ jobs:
     -
       name: Push to Docker Hub
       run: script/docker-push
+    -
+      name: Display build summary
+      run: |
+        DOCKER_IMAGE=koudaiii/azureupdatepptx
+        GIT_COMMIT=$(git rev-parse --short HEAD)
+        echo "=== Docker Build & Push Summary ==="
+        echo "Repository: $DOCKER_IMAGE"
+        echo "Git Commit: $GIT_COMMIT"
+        echo "Pushed Tags:"
+        echo "  - $DOCKER_IMAGE:$GIT_COMMIT"
+        echo "  - $DOCKER_IMAGE:latest"
+        echo "Docker Hub URL: https://hub.docker.com/r/koudaiii/azureupdatepptx"
+        echo "================================="

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,6 +46,7 @@ jobs:
       run: script/docker-push
     -
       name: Display build summary
+      if: success()  # Only show summary if previous steps succeeded
       run: |
         DOCKER_IMAGE=koudaiii/azureupdatepptx
         GIT_COMMIT=$(git rev-parse --short HEAD)


### PR DESCRIPTION
This pull request adds a new step to the Docker image workflow in `.github/workflows/docker-image.yml`. The change introduces a summary display after pushing the Docker image to provide clear and concise build information.

Workflow enhancement:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR47-R59): Added a new job step named "Display build summary" to show details about the Docker image repository, Git commit, pushed tags, and the Docker Hub URL after the image is pushed.