### PR TITLE
Add to job summary in docker push workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DOCKER_IMAGE: "koudaiii/azureupdatepptx"
+
 jobs:
 
   build:
@@ -45,11 +48,12 @@ jobs:
       name: Push to Docker Hub
       run: script/docker-push
     -
-      name: Display build summary
-      if: success()  # Only show summary if previous steps succeeded
+      name: Display build summary and add to job summary
+      if: success()
       run: |
-        DOCKER_IMAGE=koudaiii/azureupdatepptx
         GIT_COMMIT=$(git rev-parse --short HEAD)
+
+        # Display in console
         echo "=== Docker Build & Push Summary ==="
         echo "Repository: $DOCKER_IMAGE"
         echo "Git Commit: $GIT_COMMIT"
@@ -58,13 +62,12 @@ jobs:
         echo "  - $DOCKER_IMAGE:latest"
         echo "Docker Hub URL: https://hub.docker.com/r/koudaiii/azureupdatepptx"
         echo "================================="
-    -
-      name: Add to job summary
-      if: success()  # Only add to summary if previous steps succeeded
-      run: |
-        DOCKER_IMAGE=koudaiii/azureupdatepptx
-        GIT_COMMIT=$(git rev-parse --short HEAD)
+
+        # Add to GitHub step summary
         echo "### Docker Build & Push Summary" >> $GITHUB_STEP_SUMMARY
-        echo "Pushed Tags:" >> $GITHUB_STEP_SUMMARY
-        echo "  - $DOCKER_IMAGE:$GIT_COMMIT" >> $GITHUB_STEP_SUMMARY
-        echo "  - $DOCKER_IMAGE:latest" >> $GITHUB_STEP_SUMMARY
+        echo "**Repository:** $DOCKER_IMAGE" >> $GITHUB_STEP_SUMMARY
+        echo "**Git Commit:** $GIT_COMMIT" >> $GITHUB_STEP_SUMMARY
+        echo "**Pushed Tags:**" >> $GITHUB_STEP_SUMMARY
+        echo "- \`$DOCKER_IMAGE:$GIT_COMMIT\`" >> $GITHUB_STEP_SUMMARY
+        echo "- \`$DOCKER_IMAGE:latest\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Docker Hub:** https://hub.docker.com/r/koudaiii/azureupdatepptx" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,3 +58,13 @@ jobs:
         echo "  - $DOCKER_IMAGE:latest"
         echo "Docker Hub URL: https://hub.docker.com/r/koudaiii/azureupdatepptx"
         echo "================================="
+    -
+      name: Add to job summary
+      if: success()  # Only add to summary if previous steps succeeded
+      run: |
+        DOCKER_IMAGE=koudaiii/azureupdatepptx
+        GIT_COMMIT=$(git rev-parse --short HEAD)
+        echo "### Docker Build & Push Summary" >> $GITHUB_STEP_SUMMARY
+        echo "Pushed Tags:" >> $GITHUB_STEP_SUMMARY
+        echo "  - $DOCKER_IMAGE:$GIT_COMMIT" >> $GITHUB_STEP_SUMMARY
+        echo "  - $DOCKER_IMAGE:latest" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request adds a new step to the Docker image workflow to enhance the job summary. The step ensures that a detailed summary of the Docker build and push process is appended to the GitHub Actions job summary if all previous steps succeed.

Enhancements to job summary:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR61-R70): Added a new step named "Add to job summary" that appends a Docker build and push summary to `$GITHUB_STEP_SUMMARY`, including pushed tags (`latest` and the short Git commit hash), conditional on the success of prior steps.